### PR TITLE
fix(sidebar): ensure sidebar items remain fixed on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,18 +132,6 @@
       <span>Toggle Issues Panel</span>
     </button>
 
-    <aside
-      id="live-issues-section"
-      class="live-issues-sidebar"
-      aria-labelledby="live-issues-heading"
-    >
-      <h2 id="live-issues-heading" class="visually-hidden">
-        Live GitHub Issues
-      </h2>
-      <ul id="live-issues-list">
-        <!-- Issues will be loaded here -->
-      </ul>
-    </aside>
 
     <footer>
       <p>
@@ -160,5 +148,20 @@
 
     <audio id="cat-sound" src="sounds/cat-meow-1.mp3" preload="auto"></audio>
     <script type="module" src="script.js" defer></script>
+
+    <aside
+      id="live-issues-section"
+      class="live-issues-sidebar"
+      aria-labelledby="live-issues-heading"
+    >
+      <h2 id="live-issues-heading" class="visually-hidden">
+        Live GitHub Issues
+      </h2>
+      <div class="live-issues-scrollable"></div>
+      <ul id="live-issues-list">
+         <!-- Issues will be loaded here  -->
+      </ul>
+    </aside> 
+
   </body>
 </html>

--- a/styles/live-issues-sidebar.css
+++ b/styles/live-issues-sidebar.css
@@ -73,6 +73,8 @@
 /* Content within the sidebar (heading and list) */
 /* Ensure content doesn't overlap with the tab area */
 #live-issues-heading {
+  padding-bottom: 0;
+  margin-bottom: 0;
   /* Assuming you have a .visually-hidden class for accessibility */
   /* If not visually hidden, its color should also be themed */
   /* Content is to the left of the tab, so padding-right avoids the tab */
@@ -137,8 +139,9 @@
 
 /* --- Search Filter Input --- */
 .live-issues-search-container {
-  padding: 12px 15px 8px 15px;
+  padding: 12px 15px 0 15px;
   background: var(--live-issues-sidebar-bg);
+  margin-bottom: 0;
   border-bottom: 1px solid var(--live-issues-item-border-color);
   display: flex;
   align-items: baseline; /* Align items based on their text baseline */
@@ -181,20 +184,36 @@
   white-space: nowrap;
 }
 
+.live-issues-scrollable > *:first-child {
+  
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  margin-top: 0 ;
+  padding-top: 0 ;
+  flex-direction: column;
+}
+
 /* --- Repository Group Header --- */
 .live-issue-repo-header {
+  position: sticky;
+  top: -18px;
+  z-index: 10;
   font-size: 1em;
   font-weight: bold;
   color: var(--live-issues-repo-name-text-color);
   background: var(--live-issues-sidebar-bg);
   border-bottom: 1px solid var(--live-issues-item-border-color);
-  margin-top: 12px;
+  margin-top: 0;
+  padding-top: 0;
   margin-bottom: 2px;
   padding: 6px 0 2px 0;
   letter-spacing: 0.5px;
 }
 
-.live-issues-sidebar .sidebar-internal-close-btn {
+
+
+/* .live-issues-sidebar .sidebar-internal-close-btn {
   position: absolute;
   top: 10px;
   right: 10px;
@@ -207,4 +226,34 @@
   font-size: 1.2em;
   cursor: pointer;
   z-index: 1002;
+} */
+
+
+.live-issues-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--live-issues-sidebar-width);
+  height: 100vh;
+  background-color: var(--live-issues-sidebar-bg);
+  border-right: 1px solid var(--live-issues-sidebar-border-color);
+  box-shadow: 3px 0 6px var(--live-issues-sidebar-shadow-color);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 1000;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  position: fixed !important;
+  pointer-events: none; 
+  visibility: hidden;
+  opacity: 0;
 }
+
+.live-issues-sidebar.sidebar-open {
+  transform: translateX(0);
+  pointer-events: auto;
+  visibility: visible;
+  opacity: 1;
+}
+


### PR DESCRIPTION
## 🛠️ Fix Sidebar Items Shifting on Mobile Scroll

### 📋 Problem
When viewing the site, the sidebar items **"Countdown"** and **"the-ain-verse"** are not in a fixed position. As users scroll or interact with the UI, these items shift, leading to inconsistencies in layout and reduced accessibility.

---

### ✅ Expected Behavior
The sidebar menu items should remain **anchored in place** inside the sidebar panel—regardless of scroll or UI interaction—ensuring consistent navigation and better user experience.

---

### ❌ Actual Behavior
The "Countdown" and "the-ain-verse" items shift from their intended location while scrolling or interacting with other elements on the page.

---

### 🔧 Solution
- Applied `position: sticky` to key sidebar elements, scoped appropriately within the sidebar layout.
- Added appropriate `overflow` rules to maintain scroll containment without displacing fixed items.


