### PR TITLE
Fix/social icon alignment

### DIFF
--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -27,10 +27,25 @@ header h1 {
 }
 
 .social-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-color);
   font-size: 1.5rem;
-  transition: color 0.2s ease, transform 0.2s ease;
+  width: 2.2rem;
+  height: 2.2rem;
+  line-height: 1;
+  vertical-align: middle;
+  box-sizing: border-box;
+  padding: 0; /* make sure no default padding interferes */
 }
+
+.social-links a svg {
+  display: block;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
 
 .social-links a:hover {
   color: var(--accent-color);
@@ -42,16 +57,17 @@ header h1 {
 }
 
 #theme-toggle {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
-  padding: 0.5rem;
-  display: flex;
+  font-size: 1.6rem;
+  padding: 0.3rem;
+  height: 2.2rem;
+  width: 2.2rem;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   transition: transform 0.2s ease;
 }
+
 
 #theme-toggle:hover {
   transform: rotate(15deg);


### PR DESCRIPTION
## Description

This pull request addresses Issue #12 by fixing the vertical misalignment of social media icons in the header on smaller screens. On mobile view, icons like GitHub appeared slightly lower than others (such as the emoji-based theme toggle), disrupting visual balance.

The solution uses consistent sizing and layout techniques (e.g. `inline-flex`, `align-items: center`, normalized SVG rendering) to ensure that all header elements stay perfectly aligned in a single horizontal row.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional context

### Before:
- On mobile view, social icons were misaligned vertically even though in the same row.
- The theme toggle (emoji) did not align properly with SVG-based icons.

### After:
- Icons and theme toggle are now visually aligned using flexbox and fixed dimensions.
- Maintains a single-row responsive layout without stacking or overlap.

Closes #12
